### PR TITLE
Emit universal arm APK for 64-bit-only devices

### DIFF
--- a/src/Expandroid.csproj
+++ b/src/Expandroid.csproj
@@ -72,4 +72,10 @@
   <ItemGroup>
     <Folder Include="Resources\Images\" />
   </ItemGroup>
+  <PropertyGroup Condition="$(TargetFramework.Contains('-android')) and '$(Configuration)' == 'Release'">
+    <AndroidPackageFormat>apk</AndroidPackageFormat>
+    <AndroidCreatePackagePerAbi>false</AndroidCreatePackagePerAbi>
+    <RuntimeIdentifiers>android-arm64;android-arm</RuntimeIdentifiers>
+    <!-- <RunAOTCompilation>false</RunAOTCompilation> -->
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Problem

The IzzyOnDroid build currently serves the `armeabi-v7a` 32-bit APK. On 64-bit-only Android devices, a 32-bit-only APK fails to install with `INSTALL_FAILED_NO_MATCHING_ABIS`.

_This does not mean Expandroid has no 64-bit build anywhere; Google Play may already serve a compatible build. The goal is to make the repository's APK release output safer for direct APK / F-Droid-style distribution too._

## Change

Adds a Release PropertyGroup that emits a single universal arm/arm64 APK:

- `AndroidCreatePackagePerAbi=false`
- `RuntimeIdentifiers=android-arm64;android-arm`

This keeps 32-bit support while adding support for 64-bit-only devices.

## Tested

Tested locally before opening the PR:

- built a Release APK
- verified it installs on a physical Android device via wireless ADB
- verified the app launches successfully after installation

The local build required a temporary MudBlazor compatibility patch because a clean clone currently does not compile as-is. That temporary patch is not included in this PR.

## Notes

If the universal APK ends up too large for IzzyOnDroid, the fallback would be either:

1. uncomment `RunAOTCompilation=false` to reduce APK size, or
2. switch to `android-arm64` only, which fixes modern 64-bit-only devices but drops 32-bit support.
